### PR TITLE
Fix clock flags configuration for idf-version >= 4.3

### DIFF
--- a/si7021.c
+++ b/si7021.c
@@ -24,6 +24,9 @@ int si7021_init(i2c_port_t port, int sda_pin, int scl_pin,  gpio_pullup_t sda_in
 	conf.sda_pullup_en = sda_internal_pullup;
 	conf.scl_pullup_en = scl_internal_pullup;
 	conf.master.clk_speed = 100000;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0)
+        conf.clk_flags = 0;
+#endif
 	ret = i2c_param_config(port, &conf);
 	if( ret != ESP_OK ) return SI7021_ERR_CONFIG;
 


### PR DESCRIPTION
When i2c_config_t::clk_flags is 0, the clock allocator will select only according to the desired frequency.